### PR TITLE
Config migration table name

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,18 @@ The production database sees the migrations applied out of order with respect to
 
 A `migrations` table is created as the first migration, before any user-supplied migrations. This keeps track of all the migrations which have already been run.
 
+You can specify a different name by passing a config object as the third parameter to `migrate` with the property `migrationTableName`, as shown below:
+
+```js
+const { migrate} = require("postgres-migrations")
+
+migrate(
+  dbConfig
+  "path/to/migration/files",
+  { migrationTableName: "custom_migrations_table"}
+)
+```
+
 ### Hash checks for previous migrations
 
 Previously run migration scripts shouldn't be modified, since we want the process to be repeated in the same way for every new environment.

--- a/src/files-loader.js
+++ b/src/files-loader.js
@@ -28,7 +28,7 @@ module.exports.load = async (directory, log) => {
   let orderedMigrations = []
   if (fileNames) {
     const migrationFiles = [
-      path.join(__dirname, "migrations/0_create-migrations-table.sql"),
+      path.join(__dirname, "migrations/0_index-place-holder.sql"),
       ...fileNames.reduce(filterAndResolveFileName(directory), []),
     ]
 

--- a/src/migrate.js
+++ b/src/migrate.js
@@ -54,6 +54,9 @@ async function runMigrations(dbConfig, migrationsDirectory, config) {
 
     validateMigrations(migrations, appliedMigrations)
 
+    await createMigrationsTable(client)
+    log("Migrations table created")
+
     const filteredMigrations = filterMigrations(migrations, appliedMigrations)
 
     const completedMigrations = []
@@ -78,6 +81,17 @@ async function runMigrations(dbConfig, migrationsDirectory, config) {
       await client.end()
     } catch (e) {} // eslint-disable-line
   }
+}
+
+function createMigrationsTable(client) {
+  return client.query(`
+    CREATE TABLE IF NOT EXISTS migrations (
+      id integer PRIMARY KEY,
+      name varchar(100) UNIQUE NOT NULL,
+      hash varchar(40) NOT NULL,
+      executed_at timestamp DEFAULT current_timestamp
+    );
+  `)
 }
 
 // Queries the database for migrations table and retrieve it rows if exists

--- a/src/migrate.js
+++ b/src/migrate.js
@@ -30,7 +30,7 @@ module.exports = async function migrate(
 async function runMigrations(dbConfig, migrationsDirectory, config) {
   const log = config.logger || (() => {})
 
-  const migrationTableName = "migrations"
+  const migrationTableName = config.migrationTableName || "migrations"
 
   const client = new pg.Client(dbConfig)
 
@@ -54,7 +54,7 @@ async function runMigrations(dbConfig, migrationsDirectory, config) {
 
     validateMigrations(migrations, appliedMigrations)
 
-    await createMigrationsTable(client)
+    await createMigrationsTable(client, migrationTableName)
     log("Migrations table created")
 
     const filteredMigrations = filterMigrations(migrations, appliedMigrations)
@@ -83,9 +83,9 @@ async function runMigrations(dbConfig, migrationsDirectory, config) {
   }
 }
 
-function createMigrationsTable(client) {
+function createMigrationsTable(client, migrationTableName) {
   return client.query(`
-    CREATE TABLE IF NOT EXISTS migrations (
+    CREATE TABLE IF NOT EXISTS ${migrationTableName} (
       id integer PRIMARY KEY,
       name varchar(100) UNIQUE NOT NULL,
       hash varchar(40) NOT NULL,

--- a/src/migrations/0_create-migrations-table.sql
+++ b/src/migrations/0_create-migrations-table.sql
@@ -1,6 +1,0 @@
-CREATE TABLE IF NOT EXISTS migrations (
-  id integer PRIMARY KEY,
-  name varchar(100) UNIQUE NOT NULL,
-  hash varchar(40) NOT NULL, -- sha1 hex encoded hash of the file name and contents, to ensure it hasn't been altered since applying the migration
-  executed_at timestamp DEFAULT current_timestamp
-);

--- a/src/migrations/0_index-place-holder.sql
+++ b/src/migrations/0_index-place-holder.sql
@@ -1,0 +1,3 @@
+-- This file exists so that the other migration files' orders and array index will match
+-- (e.g. 1-script.sql will be the 2nd row (index 1) in the database)
+-- It makes the code much simpler in a few places


### PR DESCRIPTION
I took a swing at this, appears to be working well.  I kept the 0.sql file because there are a lot of assumptions in the code that the file name index will match the index of that file's entry in the `migrations` table, and without that 1.sql would be in the 0th index, for example. It feels slightly hacky, but I think it prevents the code from getting unnecessarily complex enough that it's worth the tradeoff.

Closes #4 