### PR TITLE
Ensure file extension is `js` or `sql` exactly

### DIFF
--- a/src/files-loader.ts
+++ b/src/files-loader.ts
@@ -6,7 +6,7 @@ import {Logger, Migration} from "./types"
 
 const readDir = promisify(fs.readdir)
 
-const isValidFile = (fileName: string) => /.(sql|js)$/gi.test(fileName)
+const isValidFile = (fileName: string) => /\.(sql|js)$/gi.test(fileName)
 
 export const load = async (
   directory: string,


### PR DESCRIPTION
The current regex checks that a file ends with `sql` or `js`. This pull request would change the behavior to check if a file ends with `.sql` or `.js`.

My current use case is that while working on a new migration script, I don't want the migration runner to run it because then I can't make changes to the file without removing the related row from the `migrations` table.

To overcome this, I was hoping to name my in-progress files `.devsql` so they would be skipped.

This is _technically_ a breaking change in that someone could have all of their migration files end with `.awesomesql` and they would have been picked up prior to this change, but not after. But that also seems unlikely and I suspect the period at the beginning of the regex was meant to capture an actual period and not "match everything".

I would be curious to get your thoughts on this approach, if this behavior is even desirable, and if not if you have any other suggestions on how to achieve what I'm trying to do.