### PR TITLE
extend the MigrateDBConfig to pass the ssl property

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -18,8 +18,16 @@ export interface CreateDBConfig extends BaseDBConfig {
   readonly defaultDatabase?: string
 }
 
+export interface SslConfig {
+  readonly rejectUnauthorized: boolean
+  readonly ca?: string
+  readonly key?: string
+  readonly cert?: string
+}
+
 export interface MigrateDBConfig extends BaseDBConfig {
   readonly database: string
+  readonly ssl?: SslConfig
 }
 
 export type Logger = (msg: string) => void


### PR DESCRIPTION
This allows the usage of the ssl property, which is passed down to the pg driver. The migrate  function utilizes the full pg driver to connect to the database and use the tls options. Right now, it allows you to run migrations, no db creation.

This PR is used to avoid the error:

``` bash
error TS2345: Object literal may only specify known properties, and 'ssl' does not exist in type 'MigrateDBConfig'.
```

Refs: #25