### PR TITLE
Adding SSL Support (For Cloud Databases, etc.)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ Requires Node 8.9.3+
 
 Supports PostgreSQL 9.4+
 
+Supports SSL
+
 ## API
 
 ```js
@@ -22,6 +24,7 @@ createDb("database-name", {
   password: "password",
   host: "localhost",
   port: 5432,
+  ssl: true, //optional, defaults: false
 })
 .then(() => {
   return migrate({
@@ -30,6 +33,7 @@ createDb("database-name", {
     password: "password",
     host: "localhost",
     port: 5432,
+    ssl: true,
   }, "path/to/migration/files")
 })
 .then(() => {/* ... */})

--- a/src/__tests__/create.ts
+++ b/src/__tests__/create.ts
@@ -21,6 +21,7 @@ test("successful creation", t => {
     password: PASSWORD,
     host: "localhost",
     port,
+    ssl: false,
   })
 })
 
@@ -33,6 +34,7 @@ test("bad arguments - no database name", t => {
         password: PASSWORD,
         host: "localhost",
         port,
+        ssl: false,
       }),
     )
     .then(err => {
@@ -59,6 +61,7 @@ test("bad arguments - incorrect user", t => {
         password: PASSWORD,
         host: "localhost",
         port,
+        ssl: false,
       }),
     )
     .then(err => {
@@ -74,6 +77,7 @@ test("bad arguments - incorrect password", t => {
         password: "not_the_password",
         host: "localhost",
         port,
+        ssl: false,
       }),
     )
     .then(err => {
@@ -89,6 +93,7 @@ test("bad arguments - incorrect host", t => {
         password: PASSWORD,
         host: "sillyhost",
         port,
+        ssl: false,
       }),
     )
     .then(err => {
@@ -104,6 +109,7 @@ test("bad arguments - incorrect port", t => {
         password: PASSWORD,
         host: "localhost",
         port: 1234,
+        ssl: false,
       }),
     )
     .then(err => {
@@ -119,6 +125,7 @@ test("already created", t => {
       password: PASSWORD,
       host: "localhost",
       port,
+      ssl: false,
     })
 
   return create().then(create)
@@ -133,6 +140,7 @@ test("database name included in config", t => {
       password: PASSWORD,
       host: "localhost",
       port,
+      ssl: false,
       // tslint:disable-next-line no-any
     } as any)
 
@@ -148,6 +156,7 @@ test("custom default database name", t => {
       password: PASSWORD,
       host: "localhost",
       port,
+      ssl: false,
     })
 
   return create().then(create)

--- a/src/__tests__/migrate.ts
+++ b/src/__tests__/migrate.ts
@@ -26,6 +26,7 @@ test("successful first migration", t => {
     password: PASSWORD,
     host: "localhost",
     port,
+    ssl: false,
   }
 
   return createDb(databaseName, dbConfig)
@@ -44,6 +45,7 @@ test("successful second migration", t => {
     password: PASSWORD,
     host: "localhost",
     port,
+    ssl: false,
   }
 
   return createDb(databaseName, dbConfig)
@@ -63,6 +65,7 @@ test("successful first javascript migration", t => {
     password: PASSWORD,
     host: "localhost",
     port,
+    ssl: false,
   }
 
   return createDb(databaseName, dbConfig)
@@ -81,6 +84,7 @@ test("successful second mixed js and sql migration", t => {
     password: PASSWORD,
     host: "localhost",
     port,
+    ssl: false,
   }
 
   return createDb(databaseName, dbConfig)
@@ -102,6 +106,7 @@ test("successful complex js migration", t => {
     password: PASSWORD,
     host: "localhost",
     port,
+    ssl: false,
   }
 
   return createDb(databaseName, dbConfig)
@@ -129,6 +134,7 @@ test("bad arguments - no migrations directory argument", t => {
         password: PASSWORD,
         host: "localhost",
         port,
+        ssl: false,
       }),
     )
     .then(err => {
@@ -146,6 +152,7 @@ test("bad arguments - incorrect user", t => {
           password: PASSWORD,
           host: "localhost",
           port,
+          ssl: false,
         },
         "src/__tests__/fixtures/empty",
       ),
@@ -165,6 +172,7 @@ test("bad arguments - incorrect password", t => {
           password: "not_the_password",
           host: "localhost",
           port,
+          ssl: false,
         },
         "src/__tests__/fixtures/empty",
       ),
@@ -184,6 +192,7 @@ test("bad arguments - incorrect host", t => {
           password: PASSWORD,
           host: "sillyhost",
           port,
+          ssl: false,
         },
         "src/__tests__/fixtures/empty",
       ),
@@ -203,6 +212,7 @@ test("bad arguments - incorrect port", t => {
           password: PASSWORD,
           host: "localhost",
           port: 1234,
+          ssl: false,
         },
         "src/__tests__/fixtures/empty",
       ),
@@ -222,6 +232,7 @@ test("no database", t => {
           password: PASSWORD,
           host: "localhost",
           port,
+          ssl: false,
         },
         "src/__tests__/fixtures/empty",
       ),
@@ -242,6 +253,7 @@ test("no migrations dir", t => {
     password: PASSWORD,
     host: "localhost",
     port,
+    ssl: false,
   }
 
   const promise = createDb(databaseName, dbConfig).then(() => {
@@ -262,6 +274,7 @@ test("empty migrations dir", async t => {
     password: PASSWORD,
     host: "localhost",
     port,
+    ssl: false,
   }
 
   await createDb(databaseName, dbConfig).then(() => {
@@ -277,6 +290,7 @@ test("non-consecutive ordering", t => {
     password: PASSWORD,
     host: "localhost",
     port,
+    ssl: false,
   }
 
   const promise = createDb(databaseName, dbConfig).then(() => {
@@ -296,6 +310,7 @@ test("not starting from one", t => {
     password: PASSWORD,
     host: "localhost",
     port,
+    ssl: false,
   }
 
   const promise = createDb(databaseName, dbConfig).then(() => {
@@ -315,6 +330,7 @@ test("negative ID", t => {
     password: PASSWORD,
     host: "localhost",
     port,
+    ssl: false,
   }
 
   const promise = createDb(databaseName, dbConfig).then(() => {
@@ -335,6 +351,7 @@ test("invalid file name", t => {
     password: PASSWORD,
     host: "localhost",
     port,
+    ssl: false,
   }
 
   const promise = createDb(databaseName, dbConfig).then(() => {
@@ -355,6 +372,7 @@ test("syntax error", t => {
     password: PASSWORD,
     host: "localhost",
     port,
+    ssl: false,
   }
 
   const promise = createDb(databaseName, dbConfig).then(() => {
@@ -374,6 +392,7 @@ test("bad javascript file - no generateSql method exported", t => {
     password: PASSWORD,
     host: "localhost",
     port,
+    ssl: false,
   }
 
   const promise = createDb(databaseName, dbConfig).then(() => {
@@ -393,6 +412,7 @@ test("bad javascript file - generateSql not returning string literal", t => {
     password: PASSWORD,
     host: "localhost",
     port,
+    ssl: false,
   }
 
   const promise = createDb(databaseName, dbConfig).then(() => {
@@ -412,6 +432,7 @@ test("hash check failure", t => {
     password: PASSWORD,
     host: "localhost",
     port,
+    ssl: false,
   }
 
   const promise = createDb(databaseName, dbConfig)
@@ -436,6 +457,7 @@ test("rollback", t => {
     password: PASSWORD,
     host: "localhost",
     port,
+    ssl: false,
   }
 
   const promise = createDb(databaseName, dbConfig).then(() =>

--- a/src/create.ts
+++ b/src/create.ts
@@ -20,7 +20,8 @@ export async function createDb(
     typeof dbConfig.user !== "string" ||
     typeof dbConfig.password !== "string" ||
     typeof dbConfig.host !== "string" ||
-    typeof dbConfig.port !== "number"
+    typeof dbConfig.port !== "number" ||
+    typeof dbConfig.ssl !== "boolean"
   ) {
     throw new Error("Database config problem")
   }
@@ -33,7 +34,7 @@ async function create(
   dbConfig: CreateDBConfig,
   config: Config = {},
 ) {
-  const {user, password, host, port} = dbConfig
+  const {user, password, host, port, ssl} = dbConfig
 
   const log =
     config.logger != null
@@ -52,6 +53,7 @@ async function create(
     password,
     host,
     port,
+    ssl: ssl != null ? ssl : "false",
   }
 
   try {

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,6 +12,7 @@ export interface BaseDBConfig {
   readonly password: string
   readonly host: string
   readonly port: number
+  readonly ssl: boolean
 }
 
 export interface CreateDBConfig extends BaseDBConfig {


### PR DESCRIPTION
We loved your library, and wanted to use it for AWS databases. In order to do so, we needed to add SSL support. Thanx!

@jamesMart77