### PR TITLE
Make `doesTableExist` check for table in current search path

### DIFF
--- a/src/migrate.ts
+++ b/src/migrate.ts
@@ -188,14 +188,13 @@ function logResult(completedMigrations: Array<Migration>, log: Logger) {
   }
 }
 
-/** Check whether table exists in postgres - http://stackoverflow.com/a/24089729 */
+/** Check whether table exists in postgres in the current search path
+ * http://stackoverflow.com/a/24089729
+ * https://dba.stackexchange.com/a/86098
+ */
 async function doesTableExist(client: BasicPgClient, tableName: string) {
-  const result = await client.query(SQL`SELECT EXISTS (
-  SELECT 1
-  FROM   pg_catalog.pg_class c
-  WHERE  c.relname = ${tableName}
-  AND    c.relkind = 'r'
-);`)
-
+  const result = await client.query(
+    SQL`SELECT to_regclass(${tableName}) is not NULL as exists;`,
+  )
   return result.rows.length > 0 && result.rows[0].exists
 }


### PR DESCRIPTION
* If a `migrations` table did exist in a schema outside of the search path, `doesTableExist` would return true but the migration would then fail with 'relation "migrations" does not exist'
* See https://dba.stackexchange.com/a/86098 for the details on the query
* This new query makes it possible to have one `migrations` table per schema (in other words to have each schema handle its own migrations)