### PR TITLE
Fix syntax error in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ import {createDb, migrate} from "postgres-migrations"
 
 async function() {
   const dbConfig = {
-    database: "database-name"
+    database: "database-name",
     user: "postgres",
     password: "password",
     host: "localhost",


### PR DESCRIPTION
For those starting to use this script it is quite common to copy-paste from the readme. So fixing a simple syntax error makes using this that much convenient!