### PR TITLE
Implement custom migration table name

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,24 @@ async function() {
 }
 ```
 
+You can pass a custom migration table name:
+
+```typescript
+await migrate(dbConfig, "path/to/migration/files", {
+  migrationTableName: "my_migrations",
+})
+```
+
+This could, alternatively, be a table in an existing schema:
+
+```typescript
+await createDb(databaseName, {client})
+await client.query("CREATE SCHEMA IF NOT EXISTS my_schema")
+await migrate(dbConfig, "path/to/migration/files", {
+  migrationTableName: "my_schema.migrations",
+})
+```
+
 ## Design decisions
 
 ### No down migrations

--- a/src/__unit__/migration-file/index.ts
+++ b/src/__unit__/migration-file/index.ts
@@ -3,8 +3,8 @@ import {load} from "../../migration-file"
 
 test("Hashes of JS files should be the same when the SQL is the same", async (t) => {
   const [js1, js2] = await Promise.all([
-    load(__dirname + "/fixtures/different-js-same-sql-1/1_js.js"),
-    load(__dirname + "/fixtures/different-js-same-sql-2/1_js.js"),
+    load({filePath: __dirname + "/fixtures/different-js-same-sql-1/1_js.js"}),
+    load({filePath: __dirname + "/fixtures/different-js-same-sql-2/1_js.js"}),
   ])
 
   t.is(js1.hash, js2.hash)
@@ -12,8 +12,8 @@ test("Hashes of JS files should be the same when the SQL is the same", async (t)
 
 test("Hashes of JS files should be different when the SQL is different", async (t) => {
   const [js1, js2] = await Promise.all([
-    load(__dirname + "/fixtures/same-js-different-sql-1/1_js.js"),
-    load(__dirname + "/fixtures/same-js-different-sql-2/1_js.js"),
+    load({filePath: __dirname + "/fixtures/same-js-different-sql-1/1_js.js"}),
+    load({filePath: __dirname + "/fixtures/same-js-different-sql-2/1_js.js"}),
   ])
 
   t.not(js1.hash, js2.hash)

--- a/src/files-loader.ts
+++ b/src/files-loader.ts
@@ -11,6 +11,7 @@ const isValidFile = (fileName: string) => /\.(sql|js)$/gi.test(fileName)
 export const load = async (
   directory: string,
   log: Logger,
+  setupContext: {migrationTableName: string},
 ): Promise<Array<Migration>> => {
   log(`Loading migrations from: ${directory}`)
 
@@ -19,9 +20,17 @@ export const load = async (
 
   if (fileNames != null) {
     const migrationFiles = [
-      path.join(__dirname, "migrations/0_create-migrations-table.sql"),
-      ...fileNames.map((fileName) => path.resolve(directory, fileName)),
-    ].filter(isValidFile)
+      {
+        filePath: path.join(
+          __dirname,
+          "migrations/0_create-migrations-table.js",
+        ),
+        context: setupContext,
+      },
+      ...fileNames.map((fileName) => ({
+        filePath: path.resolve(directory, fileName),
+      })),
+    ].filter(({filePath}) => isValidFile(filePath))
 
     const unorderedMigrations = await Promise.all(
       migrationFiles.map(loadMigrationFile),

--- a/src/load-sql-from-js.ts
+++ b/src/load-sql-from-js.ts
@@ -1,6 +1,6 @@
 import * as path from "path"
 
-export const loadSqlFromJs = (filePath: string): string => {
+export const loadSqlFromJs = (filePath: string, context?: {}): string => {
   const migrationModule = require(filePath)
   if (!migrationModule.generateSql) {
     throw new Error(`Invalid javascript migration file: '${path.basename(
@@ -8,7 +8,7 @@ export const loadSqlFromJs = (filePath: string): string => {
     )}'.
 It must to export a 'generateSql' function.`)
   }
-  const generatedValue = migrationModule.generateSql()
+  const generatedValue = migrationModule.generateSql(context)
   if (typeof generatedValue !== "string") {
     throw new Error(`Invalid javascript migration file: '${path.basename(
       filePath,

--- a/src/migration-file.ts
+++ b/src/migration-file.ts
@@ -18,12 +18,13 @@ const getSqlStringLiteral = (
   filePath: string,
   contents: string,
   type: "js" | "sql",
+  context?: {},
 ) => {
   switch (type) {
     case "sql":
       return contents
     case "js":
-      return loadSqlFromJs(filePath)
+      return loadSqlFromJs(filePath, context)
     default: {
       const exhaustiveCheck: never = type
       return exhaustiveCheck
@@ -31,13 +32,19 @@ const getSqlStringLiteral = (
   }
 }
 
-export const load = async (filePath: string) => {
+export const load = async ({
+  filePath,
+  context,
+}: {
+  filePath: string
+  context?: {}
+}) => {
   const fileName = getFileName(filePath)
 
   try {
     const {id, name, type} = parseFileName(fileName)
     const contents = await getFileContents(filePath)
-    const sql = getSqlStringLiteral(filePath, contents, type)
+    const sql = getSqlStringLiteral(filePath, contents, type, context)
     const hash = hashString(fileName + sql)
 
     return {

--- a/src/migrations/0_create-migrations-table.js
+++ b/src/migrations/0_create-migrations-table.js
@@ -1,0 +1,9 @@
+module.exports = {
+  generateSql: ({migrationTableName}) => `
+    CREATE TABLE IF NOT EXISTS ${migrationTableName} (
+      id integer PRIMARY KEY,
+      name varchar(100) UNIQUE NOT NULL,
+      hash varchar(40) NOT NULL, -- sha1 hex encoded hash of the file name and contents, to ensure it hasn't been altered since applying the migration
+      executed_at timestamp DEFAULT current_timestamp
+    )`,
+}

--- a/src/migrations/0_create-migrations-table.sql
+++ b/src/migrations/0_create-migrations-table.sql
@@ -1,6 +1,0 @@
-CREATE TABLE IF NOT EXISTS migrations (
-  id integer PRIMARY KEY,
-  name varchar(100) UNIQUE NOT NULL,
-  hash varchar(40) NOT NULL, -- sha1 hex encoded hash of the file name and contents, to ensure it hasn't been altered since applying the migration
-  executed_at timestamp DEFAULT current_timestamp
-);

--- a/src/types.ts
+++ b/src/types.ts
@@ -39,6 +39,7 @@ export type Config = Partial<FullConfig>
 
 export interface FullConfig {
   readonly logger: Logger
+  readonly migrationTableName: string
 }
 
 export class MigrationError extends Error {


### PR DESCRIPTION
This enables users to pass their own migration table name.

Migrate can now be called like:

```typescript
await migrate(dbConfig, "path/to/migration/files", {
  migrationTableName: "schema.my_migrations",
})
```

I didn't manage to get the tests running locally so they may need looking at. Let me know if you want any changes!
