### PR TITLE
Change strategy for creating database

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 5.3.0
+
+- [DEPRECATION] Deprecate `createDb`
+- Add `ensureDatabaseExists` to check/create database in `migrate`
+
 ## 5.1.0
 
 - Validate migration ordering when loading files (instead of when applying migrations)

--- a/src/__tests__/fixtures/ensure-exists/1_success.sql
+++ b/src/__tests__/fixtures/ensure-exists/1_success.sql
@@ -1,0 +1,3 @@
+CREATE TABLE success (
+  id integer
+);

--- a/src/create.ts
+++ b/src/create.ts
@@ -4,6 +4,9 @@ import {withConnection} from "./with-connection"
 
 const DUPLICATE_DATABASE = "42P04"
 
+/**
+ * @deprecated Use `migrate` instead with `ensureDatabaseExists: true`.
+ */
 export async function createDb(
   dbName: string,
   dbConfig: CreateDBConfig,
@@ -25,7 +28,7 @@ export async function createDb(
   }
 
   if ("client" in dbConfig) {
-    return betterCreate(dbName, log)(dbConfig.client)
+    return runCreateQuery(dbName, log)(dbConfig.client)
   }
 
   if (
@@ -50,12 +53,12 @@ export async function createDb(
     log(`pg client emitted an error: ${err.message}`)
   })
 
-  const runWith = withConnection(log, betterCreate(dbName, log))
+  const runWith = withConnection(log, runCreateQuery(dbName, log))
 
   return runWith(client)
 }
 
-function betterCreate(dbName: string, log: Logger) {
+export function runCreateQuery(dbName: string, log: Logger) {
   return async (client: BasicPgClient): Promise<void> => {
     await client
       .query(`CREATE DATABASE "${dbName.replace(/\"/g, '""')}"`)

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,6 +21,26 @@ export interface ClientParams {
   readonly client: pg.Client | pg.PoolClient | pg.Pool
 }
 
+export type EnsureDatabase =
+  | {
+      /**
+       * Might default to `true` in future versions
+       * @default false
+       */
+      readonly ensureDatabaseExists: true
+      /**
+       * The database to connect to when creating a database (if necessary).
+       * @default postgres
+       */
+      readonly defaultDatabase?: string
+    }
+  | {
+      readonly ensureDatabaseExists?: false
+    }
+
+/**
+ * @deprecated Use `migrate` instead with `ensureDatabaseExists: true`.
+ */
 export type CreateDBConfig =
   | (ConnectionParams & {
       /** The database to connect to when creating the new database. */
@@ -31,7 +51,7 @@ export type CreateDBConfig =
 export type MigrateDBConfig =
   | (ConnectionParams & {
       readonly database: string
-    })
+    } & EnsureDatabase)
   | ClientParams
 
 export type Logger = (msg: string) => void


### PR DESCRIPTION
Use 'ensureDatabaseExists' flag on the migrate function.

I _think_ this makes the API smaller/simpler.

This implementation also checks whether the database exists before
trying to create it, which means it _should_ work on readonly
replicas.

Fixes #57