### PR TITLE
Check table exists in current search path

### DIFF
--- a/src/__tests__/fixtures/multiple-schemas-2/1_another.sql
+++ b/src/__tests__/fixtures/multiple-schemas-2/1_another.sql
@@ -1,0 +1,3 @@
+CREATE TABLE another (
+  id integer
+);

--- a/src/__tests__/fixtures/multiple-schemas/1_success.sql
+++ b/src/__tests__/fixtures/multiple-schemas/1_success.sql
@@ -1,0 +1,3 @@
+CREATE TABLE success (
+  id integer
+);

--- a/src/migrate.ts
+++ b/src/migrate.ts
@@ -200,14 +200,13 @@ function logResult(completedMigrations: Array<Migration>, log: Logger) {
   }
 }
 
-/** Check whether table exists in postgres - http://stackoverflow.com/a/24089729 */
+/** Check whether table exists in postgres in the current search path
+ * http://stackoverflow.com/a/24089729
+ * https://dba.stackexchange.com/a/86098
+ */
 async function doesTableExist(client: BasicPgClient, tableName: string) {
-  const result = await client.query(SQL`SELECT EXISTS (
-  SELECT 1
-  FROM   pg_catalog.pg_class c
-  WHERE  c.relname = ${tableName}
-  AND    c.relkind = 'r'
-);`)
-
+  const result = await client.query(
+    SQL`SELECT to_regclass(${tableName}) is not NULL as exists;`,
+  )
   return result.rows.length > 0 && result.rows[0].exists
 }


### PR DESCRIPTION
This PR adds tests to PR #33 which will ultimately fix a bug where schemas are ignored when checking for the presence of a migrations table.

Note: the tests do fail when not using the patched code!  Hooray!

Resolves #92 