### PR TITLE
Allow to skip the default migration creating the migrations table

### DIFF
--- a/src/files-loader.ts
+++ b/src/files-loader.ts
@@ -21,6 +21,7 @@ export const loadMigrationFiles = async (
   directory: string,
   // tslint:disable-next-line no-empty
   log: Logger = () => {},
+  skipCreateMigrationTable: boolean = false,
 ): Promise<Array<Migration>> => {
   log(`Loading migrations from: ${directory}`)
 
@@ -31,8 +32,16 @@ export const loadMigrationFiles = async (
     return []
   }
 
-  const migrationFiles = [
-    path.join(__dirname, "migrations/0_create-migrations-table.sql"),
+  let migrationFiles = []
+
+  if (!skipCreateMigrationTable) {
+    migrationFiles.push(
+      path.join(__dirname, "migrations/0_create-migrations-table.sql"),
+    )
+  }
+
+  migrationFiles = [
+    ...migrationFiles,
     ...fileNames.map((fileName) => path.resolve(directory, fileName)),
   ].filter(isValidFile)
 

--- a/src/migrate.ts
+++ b/src/migrate.ts
@@ -45,7 +45,7 @@ export async function migrate(
   if (typeof migrationsDirectory !== "string") {
     throw new Error("Must pass migrations directory as a string")
   }
-  const intendedMigrations = await loadMigrationFiles(migrationsDirectory, log)
+  const intendedMigrations = await loadMigrationFiles(migrationsDirectory, log, config.skipCreateMigrationTable)
 
   if ("client" in dbConfig) {
     // we have been given a client to use, it should already be connected

--- a/src/types.ts
+++ b/src/types.ts
@@ -59,6 +59,7 @@ export type Config = Partial<FullConfig>
 
 export interface FullConfig {
   readonly logger: Logger
+  readonly skipCreateMigrationTable: boolean
 }
 
 export class MigrationError extends Error {


### PR DESCRIPTION
## Context
I'm working with [esbuild](https://esbuild.github.io/) as my bundler to include all dependencies in one .js bundle file. This makes it possible to ship my app with only the necessary dependencies included and to skip node_modules all together.

## Problem
When bundling, the code of `postgres-migrations` is correctly included but the default behaviour is to use the file `0_create-migrations-table.sql` which is not bundled as it is not used in my project directly. Thus giving the error :

```
Error: ENOENT: no such file or directory, open 'migrations/0_create-migrations-table.sql' - Offending file: '0_create-migrations-table.sql'.
```
Because the file doesn't exist from my bundled code.

## Solution
This PR adds a simple config param `skipCreateMigrationTable` to avoid using the default init table. This way I can create it myself in the `migrations` folder of my project

## Example
```typescript
await migrate({ client }, path.join(__dirname, 'migrations'), { skipCreateMigrationTable: true });
```