### PR TITLE
Include actual and expected hash in migration validation error message

### DIFF
--- a/src/validation.ts
+++ b/src/validation.ts
@@ -27,8 +27,9 @@ export function validateMigrationHashes(
   const invalidHashes = migrations.filter(invalidHash)
   if (invalidHashes.length > 0) {
     // Someone has altered one or more migrations which has already run - gasp!
-    const invalidFiles = invalidHashes.map(({fileName}) => fileName)
-    throw new Error(`Hashes don't match for migrations '${invalidFiles}'.
-This means that the scripts have changed since it was applied.`)
+    const errors = invalidHashes
+      .map(migration => `Migration failed for File: ${migration.fileName}. This means that this script has changed since it was applied.\n\tExpected Hash: ${appliedMigrations[migration.id].hash}\n\tActual Hash: ${migration.hash}`)
+      .join('\n');
+    throw new Error(errors);
   }
 }

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -28,7 +28,9 @@ export function validateMigrationHashes(
   if (invalidHashes.length > 0) {
     // Someone has altered one or more migrations which has already run - gasp!
     const errors = invalidHashes
-      .map(migration => `Migration failed for File: ${migration.fileName}. This means that this script has changed since it was applied.\n\tExpected Hash: ${appliedMigrations[migration.id].hash}\n\tActual Hash: ${migration.hash}`)
+      .map(migration => `Migration failed for File: ${migration.fileName}.`
+        + 'This means that this script has changed since it was applied.\n\t'
+        + `Expected Hash: ${appliedMigrations[migration.id].hash}\n\tActual Hash: ${migration.hash}`)
       .join('\n');
     throw new Error(errors);
   }


### PR DESCRIPTION
Particularly useful for local debugging before committing or merging the final immutable migration. It would be ideal if this behaviour could be controlled by configuration, a property that could be set to true when working in a local or development environment.